### PR TITLE
Fix for red popup for failed admin login

### DIFF
--- a/php/admin.php
+++ b/php/admin.php
@@ -94,9 +94,8 @@ body, html {
 
 	  			<?php
 
-			if(isset( $_GET['failedLogin'] ))
+			if(isset( $_GET['failedlogin'] ))
 			{
-				echo"failed";
 				echo '
 				<div class="w3-container">
 					<div class="w3-panel w3-card w3-red w3-display-container">


### PR DESCRIPTION
Wrong case for "L", it is case sensitive hence it doesn't appear at failed login (Hacktoberfest)